### PR TITLE
Partner refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+/src/main/resources/application-prod.properties
+/src/main/resources/application.properties
+
 
 ### STS ###
 .apt_generated

--- a/src/main/java/ru/planetnails/partnerslk/controller/ContractorRestControllerV1.java
+++ b/src/main/java/ru/planetnails/partnerslk/controller/ContractorRestControllerV1.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,8 +20,10 @@ import ru.planetnails.partnerslk.service.ContractorService;
 import javax.validation.Valid;
 import java.util.List;
 
+
 @RestController
 @AllArgsConstructor
+@Slf4j
 @Tag(name = "Contrators", description = "Сервис для создания/изменения, а также получения данных по контрагентам")
 @RequestMapping(value = "/api/v1/contractors")
 public class
@@ -49,6 +52,27 @@ ContractorRestControllerV1 {
         ContractorOutDto result = ContractorMapper.fromContractorToContractorOutDto(contractor);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
+
+    @Operation(summary = "Получение списка контрагентов партнёра")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Данные найдены",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ContractorOutDto.class))}),
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Данные не найдены",
+                    content = @Content)
+    })
+    @GetMapping(value = "/partner/{partnerId}")
+    public ResponseEntity<List<ContractorOutDto>> getContractorsByPartnerId(@PathVariable(name = "partnerId") String partnerId) {
+        log.info(String.format(" GET /api/v1/partner/{partnerId}; username = %s", partnerId));
+        List<ContractorOutDto> contractors = contractorService.findContractorsByPartnerId(partnerId);
+        return new ResponseEntity<>(contractors, HttpStatus.OK);
+    }
+
 
     @Operation(summary = "Добавление/обновление массива контрагентов")
     @ApiResponses(value = {

--- a/src/main/java/ru/planetnails/partnerslk/controller/PartnerRestControllerV1.java
+++ b/src/main/java/ru/planetnails/partnerslk/controller/PartnerRestControllerV1.java
@@ -18,8 +18,6 @@ import ru.planetnails.partnerslk.model.partner.dto.PartnerMapper;
 import ru.planetnails.partnerslk.model.partner.dto.PartnerOutDto;
 import ru.planetnails.partnerslk.service.PartnerService;
 
-import java.util.List;
-
 @RestController
 @Validated
 @AllArgsConstructor
@@ -29,7 +27,7 @@ import java.util.List;
 public class PartnerRestControllerV1 {
     PartnerService partnerService;
 
-    @Operation(summary = "Добавление/обновление данных партнёера")
+    @Operation(summary = "Добавление/обновление данных партнёра")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
@@ -49,13 +47,6 @@ public class PartnerRestControllerV1 {
         return "Your data has been queued.";
     }
 
-    @GetMapping
-    public List<Partner> getAllPartners() {
-        // подумать, тут должна быть учетка с админскими правами, чтобы
-        // обычный пользователь не мог дерануть такой сервис и вытащить всю информацию
-
-        return null;
-    }
 
     @Operation(summary = "Получение данных партнёра по id")
     @ApiResponses(value = {
@@ -70,7 +61,7 @@ public class PartnerRestControllerV1 {
                     description = "Данные не найдены",
                     content = @Content)
     })
-    @GetMapping(value = "/partner/{id}")
+    @GetMapping(value = "/{id}")
     public ResponseEntity<PartnerOutDto> getPartnerById(@PathVariable(name = "id") String id) {
         log.info(String.format(" GET /api/v1/partners/partner; partnerId = %s", id));
         Partner partner = partnerService.findPartnerById(id);

--- a/src/main/java/ru/planetnails/partnerslk/controller/PartnerRestControllerV1.java
+++ b/src/main/java/ru/planetnails/partnerslk/controller/PartnerRestControllerV1.java
@@ -1,16 +1,21 @@
 package ru.planetnails.partnerslk.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import ru.planetnails.partnerslk.model.partner.Partner;
 import ru.planetnails.partnerslk.model.partner.dto.PartnerAddDto;
 import ru.planetnails.partnerslk.service.PartnerService;
+
+import java.util.List;
 
 @RestController
 @Validated
 @AllArgsConstructor
 @Slf4j
+@Tag(name = "Partners", description = "Сервис для создания/изменения, а также получения данных по партнёерам")
 @RequestMapping(value = "/api/v1/partners")
 public class PartnerRestControllerV1 {
     PartnerService partnerService;
@@ -20,5 +25,10 @@ public class PartnerRestControllerV1 {
     public String add(@RequestBody PartnerAddDto partnerAddDto) {
         partnerService.add(partnerAddDto);
         return "Your data has been queued.";
+    }
+
+    @GetMapping
+    public List<Partner> getAllPartners() {
+        return null;
     }
 }

--- a/src/main/java/ru/planetnails/partnerslk/controller/PartnerRestControllerV1.java
+++ b/src/main/java/ru/planetnails/partnerslk/controller/PartnerRestControllerV1.java
@@ -1,12 +1,21 @@
 package ru.planetnails.partnerslk.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.planetnails.partnerslk.model.partner.Partner;
 import ru.planetnails.partnerslk.model.partner.dto.PartnerAddDto;
+import ru.planetnails.partnerslk.model.partner.dto.PartnerMapper;
+import ru.planetnails.partnerslk.model.partner.dto.PartnerOutDto;
 import ru.planetnails.partnerslk.service.PartnerService;
 
 import java.util.List;
@@ -15,11 +24,24 @@ import java.util.List;
 @Validated
 @AllArgsConstructor
 @Slf4j
-@Tag(name = "Partners", description = "Сервис для создания/изменения, а также получения данных по партнёерам")
+@Tag(name = "Partners", description = "Сервис для создания/изменения, а также получения данных по партнёрам")
 @RequestMapping(value = "/api/v1/partners")
 public class PartnerRestControllerV1 {
     PartnerService partnerService;
 
+    @Operation(summary = "Добавление/обновление данных партнёера")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Your data has been queued (данные получены и добавлены в очередь)",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = String.class))}),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Data error(ошибка валидации данных)",
+                    content = @Content)
+    })
     @PostMapping
     @PutMapping
     public String add(@RequestBody PartnerAddDto partnerAddDto) {
@@ -29,6 +51,102 @@ public class PartnerRestControllerV1 {
 
     @GetMapping
     public List<Partner> getAllPartners() {
+        // подумать, тут должна быть учетка с админскими правами, чтобы
+        // обычный пользователь не мог дерануть такой сервис и вытащить всю информацию
+
         return null;
+    }
+
+    @Operation(summary = "Получение данных партнёра по id")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Данные найдены",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = PartnerOutDto.class))}),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Данные не найдены",
+                    content = @Content)
+    })
+    @GetMapping(value = "/partner/{id}")
+    public ResponseEntity<PartnerOutDto> getPartnerById(@PathVariable(name = "id") String id) {
+        log.info(String.format(" GET /api/v1/partners/partner; partnerId = %s", id));
+        Partner partner = partnerService.findPartnerById(id);
+        if (partner == null) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+        PartnerOutDto result = PartnerMapper.fromPartnerToPartnerOutDto(partner);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Получение данных партнёра по username")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Данные найдены",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = PartnerOutDto.class))}),
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Данные не найдены",
+                    content = @Content)
+    })
+    @GetMapping(value = "/user/name/{username}")
+    public ResponseEntity<PartnerOutDto> getPartnerByUsername(@PathVariable(name = "username") String username) {
+        log.info(String.format(" GET /api/v1/partners/user/name/; username = %s", username));
+        Partner partner = partnerService.findPartnerByUsername(username);
+        if (partner == null) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+        PartnerOutDto result = PartnerMapper.fromPartnerToPartnerOutDto(partner);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Получение данных партнёра по user Id")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Данные найдены",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = PartnerOutDto.class))}),
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Данные не найдены",
+                    content = @Content)
+    })
+    @GetMapping(value = "/user/id/{id}")
+    public ResponseEntity<PartnerOutDto> getPartnerByUserId(@PathVariable(name = "id") String id) {
+        log.info(String.format(" GET /api/v1/partners/user/id; user id = %s", id));
+        Partner partner = partnerService.findPartnerByUserId(id);
+        if (partner == null) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+        PartnerOutDto result = PartnerMapper.fromPartnerToPartnerOutDto(partner);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Удаление информации по партнёру")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Данные найдены",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = PartnerOutDto.class))}),
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Данные не найдены",
+                    content = @Content)
+    })
+    @DeleteMapping(value = "/{id}")
+    public void deletePartner(@PathVariable(name = "id") String id) {
+        log.info(String.format(" DELETE /api/v1/partners/id; user id = %s", id));
+
+        partnerService.delete(id);
+
     }
 }

--- a/src/main/java/ru/planetnails/partnerslk/model/partner/Partner.java
+++ b/src/main/java/ru/planetnails/partnerslk/model/partner/Partner.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
-@Table(name="partners")
+@Table(name = "partners")
 @Getter
 @Setter
 @AllArgsConstructor
@@ -19,12 +19,12 @@ public class Partner {
     @Id
     private String id;
 
-    @Column (name="name")
-    private  String name;
+    @Column(name = "name")
+    private String name;
 
-    @Column (name="discount")
+    @Column(name = "discount")
     private int discount;
 
-    @Column(name ="account")
+    @Column(name = "account")
     private String account;
 }

--- a/src/main/java/ru/planetnails/partnerslk/model/partner/dto/PartnerMapper.java
+++ b/src/main/java/ru/planetnails/partnerslk/model/partner/dto/PartnerMapper.java
@@ -10,4 +10,12 @@ public class PartnerMapper {
                 .discount(partnerAddDto.getDiscount())
                 .account(partnerAddDto.getAccount()).build();
     }
+
+    public static PartnerOutDto fromPartnerToPartnerOutDto(Partner partner) {
+        return PartnerOutDto.builder()
+                .id(partner.getId())
+                .name(partner.getName())
+                .discount(partner.getDiscount())
+                .account(partner.getAccount()).build();
+    }
 }

--- a/src/main/java/ru/planetnails/partnerslk/model/partner/dto/PartnerOutDto.java
+++ b/src/main/java/ru/planetnails/partnerslk/model/partner/dto/PartnerOutDto.java
@@ -11,8 +11,9 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@Schema(description = "DTO для POST запроса")
-public class PartnerAddDto {
+@Builder
+@Schema(description = "DTO для GET запроса")
+public class PartnerOutDto {
     @NotBlank
     @Schema(description = "id партнёра")
     @Size(max = 50)

--- a/src/main/java/ru/planetnails/partnerslk/repository/ContractorRepository.java
+++ b/src/main/java/ru/planetnails/partnerslk/repository/ContractorRepository.java
@@ -3,6 +3,10 @@ package ru.planetnails.partnerslk.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ru.planetnails.partnerslk.model.contractor.Contractor;
+
+import java.util.List;
+
 @Repository
-public interface ContractorRepository extends JpaRepository<Contractor,String> {
+public interface ContractorRepository extends JpaRepository<Contractor, String> {
+    List<Contractor> findContractorsByPartnerId(String partnerId);
 }

--- a/src/main/java/ru/planetnails/partnerslk/repository/PartnerRepository.java
+++ b/src/main/java/ru/planetnails/partnerslk/repository/PartnerRepository.java
@@ -1,9 +1,35 @@
 package ru.planetnails.partnerslk.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ru.planetnails.partnerslk.model.partner.Partner;
 
 @Repository
 public interface PartnerRepository extends JpaRepository<Partner, String> {
+
+    @Query(
+            value = "" +
+                    "SELECT " +
+                    "* " +
+                    "FROM " +
+                    "partners as p " +
+                    "inner join user_partners as up on p.id=up.partner_id " +
+                    "inner join users as u on up.user_id=u.id " +
+                    "WHERE u.name = ?1",
+            nativeQuery = true)
+    Partner findPartnerByUsername(String username);
+
+    @Query(
+            value = "" +
+                    "SELECT " +
+                    "* " +
+                    "FROM " +
+                    "partners as p " +
+                    "inner join user_partners as up on p.id=up.partner_id " +
+                    "inner join users as u on up.user_id=u.id " +
+                    "WHERE u.id = ?1",
+            nativeQuery = true)
+    Partner findPartnerByUserId(String id);
+
 }

--- a/src/main/java/ru/planetnails/partnerslk/service/ContractorService.java
+++ b/src/main/java/ru/planetnails/partnerslk/service/ContractorService.java
@@ -2,6 +2,7 @@ package ru.planetnails.partnerslk.service;
 
 import ru.planetnails.partnerslk.model.contractor.Contractor;
 import ru.planetnails.partnerslk.model.contractor.dto.ContractorAddDto;
+import ru.planetnails.partnerslk.model.contractor.dto.ContractorOutDto;
 
 import java.util.List;
 
@@ -10,4 +11,6 @@ public interface ContractorService {
     void add(List<ContractorAddDto> contractors);
 
     Contractor findById(String id);
+
+    List<ContractorOutDto> findContractorsByPartnerId(String partnerId);
 }

--- a/src/main/java/ru/planetnails/partnerslk/service/PartnerService.java
+++ b/src/main/java/ru/planetnails/partnerslk/service/PartnerService.java
@@ -4,7 +4,13 @@ import ru.planetnails.partnerslk.model.partner.Partner;
 import ru.planetnails.partnerslk.model.partner.dto.PartnerAddDto;
 
 public interface PartnerService {
-    void add (PartnerAddDto partnerAddDto);
+    void add(PartnerAddDto partnerAddDto);
 
     Partner findPartnerById(String partnerId);
+
+    Partner findPartnerByUsername(String username);
+
+    Partner findPartnerByUserId(String id);
+
+    void delete(String id);
 }

--- a/src/main/java/ru/planetnails/partnerslk/service/impl/ContractorServiceImpl.java
+++ b/src/main/java/ru/planetnails/partnerslk/service/impl/ContractorServiceImpl.java
@@ -9,6 +9,7 @@ import ru.planetnails.partnerslk.exception.NotFoundException;
 import ru.planetnails.partnerslk.model.contractor.Contractor;
 import ru.planetnails.partnerslk.model.contractor.dto.ContractorAddDto;
 import ru.planetnails.partnerslk.model.contractor.dto.ContractorMapper;
+import ru.planetnails.partnerslk.model.contractor.dto.ContractorOutDto;
 import ru.planetnails.partnerslk.repository.ContractorRepository;
 import ru.planetnails.partnerslk.service.ContractorService;
 
@@ -39,5 +40,13 @@ public class ContractorServiceImpl implements ContractorService {
         Contractor contractor = contractorRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("Contrator_id not found"));
         return contractor;
+    }
+
+    @Override
+    public List<ContractorOutDto> findContractorsByPartnerId(String partnerId) {
+        List<ContractorOutDto> contractors = contractorRepository.findContractorsByPartnerId(partnerId)
+                .stream().map(ContractorMapper::fromContractorToContractorOutDto).
+                collect(Collectors.toList());
+        return contractors;
     }
 }

--- a/src/main/java/ru/planetnails/partnerslk/service/impl/PartnerServiceImpl.java
+++ b/src/main/java/ru/planetnails/partnerslk/service/impl/PartnerServiceImpl.java
@@ -10,12 +10,14 @@ import ru.planetnails.partnerslk.model.partner.Partner;
 import ru.planetnails.partnerslk.model.partner.dto.PartnerAddDto;
 import ru.planetnails.partnerslk.model.partner.dto.PartnerMapper;
 import ru.planetnails.partnerslk.repository.PartnerRepository;
+import ru.planetnails.partnerslk.repository.UserRepository;
 import ru.planetnails.partnerslk.service.PartnerService;
 
 @Service
 @Slf4j
 @AllArgsConstructor
 public class PartnerServiceImpl implements PartnerService {
+    private final UserRepository userRepository;
 
     PartnerRepository partnerRepository;
 
@@ -34,5 +36,22 @@ public class PartnerServiceImpl implements PartnerService {
     @Override
     public Partner findPartnerById(String partnerId) {
         return partnerRepository.findById(partnerId).orElseThrow(() -> new NotFoundException("partner not found"));
+    }
+
+    @Override
+    public Partner findPartnerByUsername(String username) {
+        return partnerRepository.findPartnerByUsername(username);
+
+    }
+
+    @Override
+    public Partner findPartnerByUserId(String id) {
+        return partnerRepository.findPartnerByUserId(id);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        partnerRepository.deleteById(id);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.application.name=Partner LK
-spring.profiles.active=prod
-app.message=prod
-
-

--- a/src/test/java/ru/planetnails/partnerslk/model/order/OrderTest.java
+++ b/src/test/java/ru/planetnails/partnerslk/model/order/OrderTest.java
@@ -1,0 +1,5 @@
+package ru.planetnails.partnerslk.model.order;
+
+class OrderTest {
+
+}


### PR DESCRIPTION
Привет, добавил следующие возможности:

**GET**  Partners
partners/user/name/{username} - возвращает информацию по партнёру на основании имени пользователя
partners/user/id/{userid} - возвращает информацию по партнёру на основании id пользователя
partners/{id} - возвращает информацию по партнёру на основании  его id
**DELETE**
partners/{id} - удаляет запись по партнёру на основании  его id

**GET**  Contractors
contractors/partner/{partnerId} возвращает список контрагентов для партнера

Хочу внести ясность по поводу таблицы user_partners. Такие развязочные таблицы имеют место быть, при этом их можно использовать и как "один к одному" так и "один ко многим", "многие ко многим" в зависимости от изменения требований. При этом, собрать данные средствами SQL не составляет никаких проблем, однако в случае использования Hibernate накладывается ряд ограничений. В данном случае,  это невозможность получить средствами Hibernate доступного партнёра у контрагента без изменений и правки сущностей. Однако,  мы можем использовать [JPQL ](https://www.baeldung.com/spring-data-jpa-query) с  @Query annotation и сделать любой, привычный нам запрос в БД, получить результат, который можно перевести в объекты нашего приложения. При этом, почитав форумы сложилось впечатление, что запрос JPQL более предпочтительны в случае большого объема базы, когда точный ручной запрос и запрос построенный Hibernate существенно отличаются по скорости. 
Таким образом в PartnerRepository у меня получился следующий запрос 
` @Query(
            value = "" +
                    "SELECT " +
                    "* " +
                    "FROM " +
                    "partners as p " +
                    "inner join user_partners as up on p.id=up.partner_id " +
                    "inner join users as u on up.user_id=u.id " +
                    "WHERE u.name = ?1",
            nativeQuery = true)
    Partner findPartnerByUsername(String username);`

